### PR TITLE
Problem: generators aren't controllable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ const gen = @import("generator");
 
 const Ty = struct {
     pub fn generate(_: *@This(), handle: *gen.Handle(u8)) !u8 {
-        handle.yield(0);
-        handle.yield(1);
-        handle.yield(2);
+        try handle.yield(0);
+        try handle.yield(1);
+        try handle.yield(2);
         return 3;
     }
 };


### PR DESCRIPTION
One problem with generators is that once they start, they
need to be seen through to completion. However, that is
not always desirable. Sometimes the rest of the generated values
are of no value (pun intended).

One way to deal with this is draining a generator, but this
does incur a penalty of actually executing it to the end,
and simply discarding generated values.

Solution: allow signalling cancellation to generators
between yields.

This way a generator can be terminated before it was supposed to
in the normal course of action.