### PR TITLE
Problem: performance of generator termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const std = @import("std");
 const gen = @import("generator");
 
 const Ty = struct {
-    pub fn generate(_: *@This(), handle: *gen.Handle(u8)) !u8 {
+    pub fn generate(_: *@This(), handle: *gen.Handle(u8, u8)) !u8 {
         try handle.yield(0);
         try handle.yield(1);
         try handle.yield(2);

--- a/zig.mod
+++ b/zig.mod
@@ -4,3 +4,8 @@ main: src/lib.zig
 license: MIT
 description: Async generator type
 dependencies:
+dev_dependencies:
+
+  - src: git https://github.com/Hejsil/zig-bench
+    name: bench
+    main: bench.zig

--- a/zigmod.lock
+++ b/zigmod.lock
@@ -1,0 +1,3 @@
+2
+git https://github.com/Hejsil/zig-bench commit-6706118f85b3ebdd4de08f81f310a25963886e98
+git https://github.com/Hejsil/zig-bench commit-6706118f85b3ebdd4de08f81f310a25963886e98


### PR DESCRIPTION
There's a penalty associated with returning from an async function.

I've learned this from @kprotty (thank you!) that if one to provide a
return value across suspension instead of returning from an async function,
"it [will] avoid rmw + full barrier which can slow down single threaded code in
the hot path + prevent compiler optimizations which act on the return value"

Solution: provide `Handle.finish()` helper to those who need extra performance

This also changes the signature of `Handle(T)` to `Handle(T, Return)` so it is
a breaking change.

Note that `Handle.finish` should be `noreturn` but it is not at the moment because
of a bug in the compiler https://github.com/ziglang/zig/issues/5728