### PR TITLE
Problem: access to return_value is complicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ pub fn main() !void {
     std.debug.assert((try g.next()).? == 1);
     std.debug.assert((try g.next()).? == 2);
     std.debug.assert((try g.next()) == null);
-    std.debug.assert(g.return_value().*.? == 3);
+    std.debug.assert(g.state == .Done);
+    std.debug.assert(g.return_value == 3);
 }
 ```
 


### PR DESCRIPTION
One needs to go through a pointer and an optional. It's
excessive and is hard to read.

Solution: hinge return_value validity on `Generator.state`

`Generator.return_value`'s value is undefined until `Generator.state`
becomes `.Done` and no error was raised, at which point it's supposed to have a
value.