### PR TITLE
Problem: unsafe access to undefined Generator.return_value

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ pub fn main() !void {
     std.debug.assert((try g.next()).? == 1);
     std.debug.assert((try g.next()).? == 2);
     std.debug.assert((try g.next()) == null);
-    std.debug.assert(g.state == .Done);
-    std.debug.assert(g.return_value == 3);
+    std.debug.assert(g.state.Done == 3);
 }
 ```
 

--- a/benchmarks.zig
+++ b/benchmarks.zig
@@ -35,15 +35,13 @@ pub fn benchReturnVsFinish() !void {
     var g = G.init(ty{});
 
     _ = try g.drain();
-    try expect(g.state == .Done);
-    try expect(g.return_value().*.? == 3);
+    try expect(g.state.Done == 3);
 
     const Gf = Generator(tyFinish, u8);
     var gf = Gf.init(tyFinish{});
 
     _ = try gf.drain();
-    try expect(gf.state == .Done);
-    try expect(gf.return_value().*.? == 3);
+    try expect(gf.state.Done == 3);
 
     // measure performance
 
@@ -52,14 +50,12 @@ pub fn benchReturnVsFinish() !void {
         pub fn return_value() !void {
             var gen = G.init(ty{});
             _ = try gen.drain();
-            try expect(gen.state == .Done);
-            try expect(gen.return_value().*.? == 3);
+            try expect(gen.state.Done == 3);
         }
         pub fn finish() !void {
             var gen = Gf.init(tyFinish{});
             _ = try gen.drain();
-            try expect(gen.state == .Done);
-            try expect(gen.return_value().*.? == 3);
+            try expect(gen.state.Done == 3);
         }
     });
 }


### PR DESCRIPTION
While it has been noted in the documentation that this value
is only valid if generator successfully ended, it is still
a potential source for mistakes.

Solution: move return value into .state.Done
so it can only be accessed if the union is set to .Done

This also adds .Error tag into the union to distinguish
successful terminations from unsuccessful ones.