### PR TITLE
Problem: negligible difference between finish and return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const std = @import("std");
 const gen = @import("generator");
 
 const Ty = struct {
-    pub fn generate(_: *@This(), handle: *gen.Handle(u8, u8)) !u8 {
+    pub fn generate(_: *@This(), handle: *gen.Handle(u8)) !u8 {
         try handle.yield(0);
         try handle.yield(1);
         try handle.yield(2);

--- a/benchmarks.zig
+++ b/benchmarks.zig
@@ -13,18 +13,9 @@ pub fn main() !void {
 
 pub fn benchReturnVsFinish() !void {
     std.debug.print("\n=== Benchmark: return vs finish\n", .{});
-    const tyFinish = struct {
-        pub fn generate(_: *@This(), handle: *Handle(u8, u8)) !u8 {
-            try handle.yield(0);
-            try handle.yield(1);
-            try handle.yield(2);
-            handle.finish(3);
-            unreachable;
-        }
-    };
 
     const ty = struct {
-        pub fn generate(_: *@This(), handle: *Handle(u8, u8)) !u8 {
+        pub fn generate(_: *@This(), handle: *Handle(u8)) !u8 {
             try handle.yield(0);
             try handle.yield(1);
             try handle.yield(2);
@@ -39,23 +30,12 @@ pub fn benchReturnVsFinish() !void {
     _ = try g.drain();
     try expect(g.state.Returned == 3);
 
-    const Gf = Generator(tyFinish, u8);
-    var gf = Gf.init(tyFinish{});
-
-    _ = try gf.drain();
-    try expect(gf.state.Returned == 3);
-
     // measure performance
 
     const bench = @import("bench");
     try bench.benchmark(struct {
         pub fn return_value() !void {
             var gen = G.init(ty{});
-            _ = try gen.drain();
-            try expect(gen.state.Returned == 3);
-        }
-        pub fn finish() !void {
-            var gen = Gf.init(tyFinish{});
             _ = try gen.drain();
             try expect(gen.state.Returned == 3);
         }
@@ -78,18 +58,8 @@ pub fn benchGeneratorVsCallback() !void {
 
     std.debug.print("\n=== Benchmark: generator vs callback\n", .{});
 
-    const tyFinish = struct {
-        pub fn generate(_: *@This(), handle: *Handle(u8, u8)) !u8 {
-            try handle.yield(0);
-            try handle.yield(1);
-            try handle.yield(2);
-            handle.finish(3);
-            unreachable;
-        }
-    };
-
     const ty = struct {
-        pub fn generate(_: *@This(), handle: *Handle(u8, u8)) !u8 {
+        pub fn generate(_: *@This(), handle: *Handle(u8)) !u8 {
             try handle.yield(0);
             try handle.yield(1);
             try handle.yield(2);
@@ -124,12 +94,6 @@ pub fn benchGeneratorVsCallback() !void {
     _ = try g.drain();
     try expect(g.state.Returned == 3);
 
-    const Gf = Generator(tyFinish, u8);
-    var gf = Gf.init(tyFinish{});
-
-    _ = try gf.drain();
-    try expect(gf.state.Returned == 3);
-
     // measure performance
 
     const bench = @import("bench");
@@ -144,21 +108,10 @@ pub fn benchGeneratorVsCallback() !void {
             "busy work",
         };
 
-        pub fn return_value(w: W) !void {
+        pub fn generator(w: W) !void {
             var gen = G.init(ty{});
             var frame_buffer: [64]u8 align(@alignOf(@Frame(busy_work.do))) = undefined;
             var result: anyerror!void = undefined;
-            while (try gen.next()) |v| {
-                try await @asyncCall(&frame_buffer, &result, w, .{v});
-            }
-            try expect(gen.state.Returned == 3);
-        }
-
-        pub fn finish(w: W) !void {
-            var gen = Gf.init(tyFinish{});
-            var frame_buffer: [64]u8 align(@alignOf(@Frame(busy_work.do))) = undefined;
-            var result: anyerror!void = undefined;
-
             while (try gen.next()) |v| {
                 try await @asyncCall(&frame_buffer, &result, w, .{v});
             }


### PR DESCRIPTION
Availability of two methods of completion is confusing and the difference
doesn't seem to be that huge anymore.

Solution: use suspension exit technique in generator's wrapper fn
and get rid of `Handle.finish`

This makes the code seemingly simpler, which is great.